### PR TITLE
feat: improve db notification resilience and cjs compatibility

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,16 +22,84 @@
 </p>
 
 <p align="center">
+  <a href="#package-summary">Summary</a>
+  · <a href="#use-cases">Use cases</a>
+  · <a href="#api-map">API map</a>
+  · <a href="#quick-start">Quick start</a>
+  · <a href="#installation">Installation</a>
+  · <a href="#import-entry-points">Entry points</a>
+  · <a href="#configuration-shape">Configuration</a>
+  · <a href="#built-in-case-strategy">Case strategy</a>
+</p>
+
+<p align="center">
   <a href="#installation">Installation</a>
   · <a href="#import-entry-points">Entry points</a>
+  · <a href="#configuration-shape">Configuration</a>
+  · <a href="#built-in-case-strategy">Case strategy</a>
+  · <a href="#postgresql-setup">PostgreSQL</a>
+  · <a href="#oracle-setup">Oracle</a>
   · <a href="#procedure-calls">Procedures</a>
   · <a href="#raw-sql-transactions">Raw SQL</a>
   · <a href="#notifications">Notifications</a>
+  · <a href="#dynamic-package-metadata-refresh">Metadata refresh</a>
+  · <a href="#serializers">Serializers</a>
   · <a href="#nestjs-integration">NestJS</a>
+  · <a href="#bundled-typeorm-compatible-api">TypeORM API</a>
+  · <a href="#typeorm-extension-decorators">Extensions</a>
+  · <a href="#shutdown">Shutdown</a>
+  · <a href="#common-errors">Errors</a>
   · <a href="./README.ru.md">Русский</a>
 </p>
 
 ---
+
+## Package summary
+
+`typeorm-procedure-kit` is a TypeScript database toolkit for Node.js services
+that use Oracle or PostgreSQL stored procedures, raw SQL transactions, database
+notifications, and TypeORM-style entity APIs.
+
+| Field | Value |
+| --- | --- |
+| npm package | `typeorm-procedure-kit` |
+| Runtime | Node.js `>=20` |
+| Module formats | ESM and CommonJS |
+| Supported databases | PostgreSQL through `pg`; Oracle through `oracledb` |
+| Main API | `TypeOrmProcedureKit` |
+| NestJS API | `typeorm-procedure-kit/nestjs` |
+| TypeORM-compatible API | `typeorm-procedure-kit/typeorm` |
+| Entity extension API | `typeorm-procedure-kit/typeorm-extend` |
+| Primary topics | stored procedures, raw SQL transactions, LISTEN/NOTIFY, Oracle CQN, serializers, TypeORM-compatible repositories |
+
+## Use cases
+
+Use this package when your service needs one or more of these capabilities:
+
+- Call Oracle packages or PostgreSQL schema procedures with database metadata.
+- Execute raw SQL through the same transaction and error-handling flow.
+- Subscribe to PostgreSQL `LISTEN/NOTIFY` or Oracle Continuous Query
+  Notification and restore subscriptions after connection loss.
+- Keep procedure metadata fresh through database change notifications.
+- Normalize result key casing for raw rows and TypeORM-compatible entity column
+  names.
+- Use a bundled TypeORM-compatible API without installing upstream `typeorm`.
+- Share base entity metadata between Oracle and PostgreSQL entity variants.
+
+## API map
+
+| Task | API | Import path |
+| --- | --- | --- |
+| Initialize database access | `new TypeOrmProcedureKit(config)`, `initDatabase()` | `typeorm-procedure-kit` |
+| Call a stored procedure | `db.call<T>(name, params, options?)` | `typeorm-procedure-kit` |
+| Execute raw SQL transaction | `db.callSqlTransaction<T>(sql, params?, options?)` | `typeorm-procedure-kit` |
+| Subscribe to database notifications | `db.makeNotify<T>(options, oracleOptions?)` | `typeorm-procedure-kit` |
+| Unsubscribe from notifications | `db.unlistenNotify(channel)` | `typeorm-procedure-kit` |
+| Register serializers | `db.setSerializer()`, `db.deleteSerializer()` | `typeorm-procedure-kit` |
+| Access DataSource or EntityManager | `db.dataSource`, `db.getEntityManager()` | `typeorm-procedure-kit` |
+| Use NestJS integration | `TypeOrmProcedureKitNestModule` and injection decorators | `typeorm-procedure-kit/nestjs` |
+| Use TypeORM-compatible APIs | `Entity`, `Column`, `DataSource`, `Repository` | `typeorm-procedure-kit/typeorm` |
+| Extend entity metadata | `ExtendEntity`, `ExtendColumn` | `typeorm-procedure-kit/typeorm-extend` |
 
 ## At a glance
 
@@ -40,6 +108,7 @@
 | Procedures    | Metadata-aware stored procedure calls for Oracle and PostgreSQL packages/schemas.                      |
 | SQL           | Raw SQL execution through the same transaction flow as procedure calls.                                |
 | Notifications | PostgreSQL `LISTEN/NOTIFY` and Oracle Continuous Query Notification support.                           |
+| Case strategy | Shared casing rules for native result keys and bundled TypeORM-compatible column names.                 |
 | Serialization | Built-in and custom serializers for database result values.                                            |
 | NestJS        | Global dynamic module plus focused injection decorators for the public runtime methods.                 |
 | TypeORM API   | Bundled TypeORM-compatible exports with stricter project-local types for repositories and query APIs.   |
@@ -55,7 +124,8 @@ Maintained by Paul Budanov.
 - Oracle and PostgreSQL adapters with a common procedure execution contract.
 - Automatic procedure metadata loading from database packages/schemas.
 - Runtime package metadata refresh through database notifications.
-- Configurable output key casing: `camelCase`, `lowerCase`, or `snakeCase`.
+- A built-in case strategy for native result keys and bundled
+  TypeORM-compatible column names: `camelCase`, `lowerCase`, or `snakeCase`.
 - Built-in and custom serializers for database result values.
 - NestJS integration through a global dynamic module and decorators for
   injecting individual public methods.
@@ -69,7 +139,10 @@ Maintained by Paul Budanov.
 ## Requirements
 
 - Node.js `>=20`
-- npm `>=10`
+- Any npm-registry package manager:
+  - npm
+  - Yarn
+  - pnpm
 - TypeScript with decorators enabled when using entities
 - At least one database driver installed for your target database:
   - PostgreSQL: `pg`
@@ -82,26 +155,92 @@ Maintained by Paul Budanov.
 
 ## Installation
 
-```bash
-npm install typeorm-procedure-kit
-```
+Use your package manager of choice:
 
-Install the driver for the database you use:
+| Package manager | Command |
+| --------------- | ------- |
+| npm | `npm install typeorm-procedure-kit` |
+| Yarn | `yarn add typeorm-procedure-kit` |
+| pnpm | `pnpm add typeorm-procedure-kit` |
 
-```bash
-npm install pg
-```
+Install the driver for the database you use.
 
-or:
+PostgreSQL:
 
-```bash
-npm install oracledb
-```
+| Package manager | Command |
+| --------------- | ------- |
+| npm | `npm install pg` |
+| Yarn | `yarn add pg` |
+| pnpm | `pnpm add pg` |
+
+Oracle:
+
+| Package manager | Command |
+| --------------- | ------- |
+| npm | `npm install oracledb` |
+| Yarn | `yarn add oracledb` |
+| pnpm | `pnpm add oracledb` |
 
 Install `pg-query-stream` only when you use PostgreSQL streaming:
 
-```bash
-npm install pg-query-stream
+| Package manager | Command |
+| --------------- | ------- |
+| npm | `npm install pg-query-stream` |
+| Yarn | `yarn add pg-query-stream` |
+| pnpm | `pnpm add pg-query-stream` |
+
+## Quick start
+
+This minimal PostgreSQL example initializes the kit, calls one configured
+procedure, and shuts down resources:
+
+```ts
+import { TypeOrmProcedureKit } from 'typeorm-procedure-kit';
+import type { IModuleConfig, ILoggerModule } from 'typeorm-procedure-kit';
+
+const logger: ILoggerModule = {
+  error: console.error,
+  log: console.log,
+  warn: console.warn,
+  debug: console.debug,
+  verbose: console.debug,
+};
+
+const settings: IModuleConfig = {
+  logger,
+  config: {
+    type: 'postgres',
+    parseInt8AsBigInt: true,
+    master: {
+      host: 'localhost',
+      port: 5432,
+      username: 'app',
+      password: 'secret',
+      database: 'app_db',
+    },
+    poolSize: 10,
+    packagesSettings: {
+      packages: ['billing'],
+      procedureObjectList: {
+        findInvoices: 'billing.find_invoices',
+      },
+    },
+  },
+};
+
+const db = new TypeOrmProcedureKit(settings);
+
+await db.initDatabase();
+
+try {
+  const invoices = await db.call<{ invoiceId: number }>(
+    'billing.find_invoices',
+    { customerId: 42 }
+  );
+  console.log(invoices);
+} finally {
+  await db.destroy();
+}
 ```
 
 ## Import entry points
@@ -126,6 +265,13 @@ repositories, query builders, and related classes are exported from the
 `./typeorm` entry point. For entities managed by this kit, import TypeORM APIs
 from `typeorm-procedure-kit/typeorm` instead of installing or importing the
 upstream `typeorm` package separately.
+
+| Import path | Use it for |
+| --- | --- |
+| `typeorm-procedure-kit` | `TypeOrmProcedureKit`, public types, utilities, constants |
+| `typeorm-procedure-kit/nestjs` | NestJS module, service, method injection decorators |
+| `typeorm-procedure-kit/typeorm` | Bundled TypeORM-compatible decorators, DataSource, repositories, query builders |
+| `typeorm-procedure-kit/typeorm-extend` | `ExtendEntity`, `ExtendColumn`, and related metadata extension decorators |
 
 ## Configuration shape
 
@@ -210,13 +356,89 @@ resolved case-insensitively and normalized internally.
 In PostgreSQL examples, "package" means the configured schema namespace used by
 the kit. In Oracle examples, it means an Oracle package.
 
-`procedureObjectList` keys are labels for the configuration object. Calls are
-resolved from the values, so use `db.call('billing.find_invoices')` or
-`db.call('find_invoices')` when only one package is configured.
+`procedureObjectList` is an allowlist for procedure metadata loading. Keys are
+labels for the configuration object only; values must be real database
+procedure names in `package.procedure` or `schema.procedure` form. Runtime
+calls resolve against the loaded database names, so use
+`db.call('billing.find_invoices')` or `db.call('find_invoices')` when only one
+package is configured. Do not use `procedureObjectList` keys as call aliases.
 
-If `packagesSettings.packages` is present, `initDatabase()` also creates the
-package-change notification subscription. Configure the database notification
-source before using these examples unchanged.
+If `packagesSettings.packages` is present and the packages array is non-empty,
+`initDatabase()` also creates the package-change notification subscription.
+Configure the database notification source before using these examples
+unchanged.
+
+## Built-in case strategy
+
+`typeorm-procedure-kit` has a built-in case strategy for the two places where
+database names meet application code: native result objects and the bundled
+TypeORM-compatible naming strategy. Configure it with
+`config.outKeyTransformCase` inside the database config.
+
+Supported values:
+
+| Value | Example database key | Output key |
+| ----- | -------------------- | ---------- |
+| `camelCase` | `USER_ID`, `user_id`, `user id` | `userId` |
+| `snakeCase` | `USER_ID`, `userId`, `User Id` | `user_id` |
+| `lowerCase` | `USER_ID`, `User_Id` | `user_id` |
+
+When `outKeyTransformCase` is omitted, `camelCase` is used. Unknown values also
+fall back to `camelCase` at runtime.
+
+The package creates two strategy objects from the same setting:
+
+- `NativeStrategy` transforms column names reported by `pg` or `oracledb`
+  metadata before native rows are returned from procedure calls and raw SQL
+  calls. SQL aliases are transformed too because drivers expose aliases as
+  result metadata.
+- `OrmStrategy` is installed as the DataSource naming strategy during
+  initialization. It transforms entity property names before delegating to the
+  bundled default naming strategy, so generated column names follow the
+  configured convention when a decorator does not provide an explicit name.
+
+Example:
+
+```ts
+const config: IModuleConfig = {
+  logger,
+  config: {
+    type: 'postgres',
+    master,
+    poolSize: 10,
+    parseInt8AsBigInt: true,
+    outKeyTransformCase: 'snakeCase',
+  },
+  entity: {
+    isNeedEntitySync: false,
+    entityPath: ['dist/entities/*.js'],
+  },
+  migration: {
+    isNeedMigrationStart: false,
+    migrationPath: ['dist/migrations/*.js'],
+  },
+};
+```
+
+With this configuration a raw result column such as `USER_ID` or `userId`
+becomes `user_id` in returned objects. With `camelCase`, the same value becomes
+`userId`.
+
+Important details:
+
+- The strategy changes output object keys and generated ORM column names. It
+  does not rewrite package names, procedure names, SQL text, bind placeholders,
+  table names, relation names, or notification channel names.
+- `packagesSettings.packages` should still be lowercase because procedure
+  resolution normalizes configured package/schema names internally.
+- Raw SQL bind placeholders still use the documented uppercase style such as
+  `:USER_ID`.
+- Explicit custom column names in decorators are honored by the bundled default
+  naming strategy, preserving standard TypeORM override behavior.
+- `lowerCase` only lowercases the incoming string. Use `snakeCase` when you need
+  word splitting such as `User Id` -> `user_id`.
+- Transformed names are cached for the lifetime of the kit instance and the
+  cache is cleared during `destroy()`.
 
 Oracle CQN can be configured in two modes. Server callback mode exposes a local
 port for database notifications:
@@ -457,7 +679,9 @@ await db.unlistenNotify(channel);
 
 The PostgreSQL adapter validates the channel name, opens a dedicated `pg.Client`,
 parses JSON payloads when possible, and attempts to restore the listener after
-connection errors.
+connection errors. It also runs a periodic connection health check, so a
+listener can be restored after silent network drops where PostgreSQL does not
+emit an explicit notification event.
 
 ### Oracle Continuous Query Notification
 
@@ -488,12 +712,26 @@ Passing an `operations` array creates one CQN subscription per operation; the
 returned channel string contains the generated subscription names and can be
 passed back to `unlistenNotify()` unchanged.
 
+Oracle notification defaults are:
+
+- `operations`: `oracledb.CQN_OPCODE_ALL_OPS`
+- `qos`: `oracledb.SUBSCR_QOS_ROWIDS`
+- `timeout`: 12 hours
+- `clientInitiated`: subscription option, then config default, then `false`
+
+When `operations` is an array, it must contain fewer than four operation codes.
+Use `oracledb.CQN_OPCODE_ALL_OPS` instead of listing every operation manually.
+Oracle subscriptions are also monitored by a periodic connection health check
+and restored after CQN deregistration, shutdown events, connection errors, or
+silent connection loss.
+
 ## Dynamic package metadata refresh
 
 When `packagesSettings.packages` is configured, `initDatabase()` loads package
-procedure metadata from the database and creates a package-change notification
-subscription. Make sure the database user has access to the notification source:
-PostgreSQL listens on `db_object_event` by default, and Oracle queries
+procedure metadata from the database. It also creates a package-change
+notification subscription whenever the packages array is non-empty, so make
+sure the database user has access to the notification source. PostgreSQL
+listens on `db_object_event` by default, and Oracle queries
 `SOLUTION_ROOT.DB_OBJECT_LOG`.
 
 For PostgreSQL, `listenEventName` can override the package-update notification
@@ -582,19 +820,17 @@ Async setup:
 
 ```ts
 TypeOrmProcedureKitNestModule.forRootAsync({
-  imports: [ConfigModule],
-  inject: [ConfigService],
-  useFactory: async (configService: ConfigService) => ({
+  useFactory: async () => ({
     logger: new Logger('TypeOrmProcedureKit'),
     config: {
       type: 'postgres',
       parseInt8AsBigInt: true,
       master: {
-        host: configService.getOrThrow('DB_HOST'),
-        port: Number(configService.getOrThrow('DB_PORT')),
-        username: configService.getOrThrow('DB_USER'),
-        password: configService.getOrThrow('DB_PASSWORD'),
-        database: configService.getOrThrow('DB_NAME'),
+        host: process.env.DB_HOST ?? 'localhost',
+        port: Number(process.env.DB_PORT ?? 5432),
+        username: process.env.DB_USER ?? 'app',
+        password: process.env.DB_PASSWORD ?? 'secret',
+        database: process.env.DB_NAME ?? 'app_db',
       },
       poolSize: 10,
     },

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -22,16 +22,87 @@
 </p>
 
 <p align="center">
+  <a href="#краткая-сводка">Сводка</a>
+  · <a href="#сценарии-использования">Сценарии</a>
+  · <a href="#карта-api">Карта API</a>
+  · <a href="#быстрый-старт">Быстрый старт</a>
+  · <a href="#установка">Установка</a>
+  · <a href="#точки-импорта">Точки импорта</a>
+  · <a href="#конфигурация">Конфигурация</a>
+  · <a href="#встроенная-case-strategy">Case strategy</a>
+</p>
+
+<p align="center">
   <a href="#установка">Установка</a>
   · <a href="#точки-импорта">Точки импорта</a>
+  · <a href="#конфигурация">Конфигурация</a>
+  · <a href="#встроенная-case-strategy">Case strategy</a>
+  · <a href="#postgresql">PostgreSQL</a>
+  · <a href="#oracle">Oracle</a>
   · <a href="#вызов-процедур">Процедуры</a>
   · <a href="#транзакции-с-sql-запросами-напрямую">SQL</a>
   · <a href="#уведомления">Уведомления</a>
+  · <a href="#обновление-метаданных-packages">Metadata refresh</a>
+  · <a href="#сериализаторы">Сериализаторы</a>
   · <a href="#nestjs">NestJS</a>
+  · <a href="#встроенный-typeorm-compatible-api">TypeORM API</a>
+  · <a href="#расширяющие-декораторы-typeorm">Extensions</a>
+  · <a href="#завершение-работы">Завершение</a>
+  · <a href="#частые-ошибки">Ошибки</a>
   · <a href="./README.md">English</a>
 </p>
 
 ---
+
+## Краткая сводка
+
+`typeorm-procedure-kit` — TypeScript toolkit для Node.js сервисов, которые
+работают с Oracle или PostgreSQL stored procedures, raw SQL transactions,
+database notifications и TypeORM-style entity API.
+
+| Поле | Значение |
+| --- | --- |
+| npm package | `typeorm-procedure-kit` |
+| Runtime | Node.js `>=20` |
+| Module formats | ESM и CommonJS |
+| Поддерживаемые базы | PostgreSQL через `pg`; Oracle через `oracledb` |
+| Main API | `TypeOrmProcedureKit` |
+| NestJS API | `typeorm-procedure-kit/nestjs` |
+| TypeORM-compatible API | `typeorm-procedure-kit/typeorm` |
+| Entity extension API | `typeorm-procedure-kit/typeorm-extend` |
+| Основные темы | stored procedures, raw SQL transactions, LISTEN/NOTIFY, Oracle CQN, serializers, TypeORM-compatible repositories |
+
+## Сценарии использования
+
+Используйте пакет, если сервису нужны одна или несколько возможностей:
+
+- Вызов Oracle packages или PostgreSQL schema procedures с учетом database
+  metadata.
+- Выполнение raw SQL через тот же transaction и error-handling flow.
+- Подписка на PostgreSQL `LISTEN/NOTIFY` или Oracle Continuous Query
+  Notification с восстановлением subscriptions после обрыва соединения.
+- Обновление procedure metadata во время работы через database change
+  notifications.
+- Нормализация регистра result keys для raw rows и TypeORM-compatible entity
+  column names.
+- Встроенный TypeORM-compatible API без установки upstream `typeorm`.
+- Переиспользование базовой entity metadata между Oracle и PostgreSQL entity
+  variants.
+
+## Карта API
+
+| Задача | API | Import path |
+| --- | --- | --- |
+| Инициализация доступа к базе | `new TypeOrmProcedureKit(config)`, `initDatabase()` | `typeorm-procedure-kit` |
+| Вызов stored procedure | `db.call<T>(name, params, options?)` | `typeorm-procedure-kit` |
+| Выполнение raw SQL transaction | `db.callSqlTransaction<T>(sql, params?, options?)` | `typeorm-procedure-kit` |
+| Подписка на database notifications | `db.makeNotify<T>(options, oracleOptions?)` | `typeorm-procedure-kit` |
+| Отписка от notifications | `db.unlistenNotify(channel)` | `typeorm-procedure-kit` |
+| Регистрация serializers | `db.setSerializer()`, `db.deleteSerializer()` | `typeorm-procedure-kit` |
+| Доступ к DataSource или EntityManager | `db.dataSource`, `db.getEntityManager()` | `typeorm-procedure-kit` |
+| NestJS integration | `TypeOrmProcedureKitNestModule` и injection decorators | `typeorm-procedure-kit/nestjs` |
+| TypeORM-compatible APIs | `Entity`, `Column`, `DataSource`, `Repository` | `typeorm-procedure-kit/typeorm` |
+| Расширение entity metadata | `ExtendEntity`, `ExtendColumn` | `typeorm-procedure-kit/typeorm-extend` |
 
 ## Кратко
 
@@ -40,6 +111,7 @@
 | Процедуры | Вызов хранимых процедур с учетом метаданных для Oracle и PostgreSQL packages/schemas. |
 | SQL | Выполнение SQL через тот же транзакционный поток, что и вызовы процедур. |
 | Уведомления | Поддержка PostgreSQL `LISTEN/NOTIFY` и Oracle Continuous Query Notification. |
+| Case strategy | Общие правила регистра для native result keys и встроенных TypeORM-compatible column names. |
 | Сериализация | Встроенные и пользовательские сериализаторы значений из базы. |
 | NestJS | Global dynamic module и точечные injection decorators для публичных runtime methods. |
 | TypeORM API | Встроенные TypeORM-совместимые экспорты со строгими локальными типами repository и query API. |
@@ -55,8 +127,8 @@
 - Общий контракт адаптеров для Oracle и PostgreSQL.
 - Автоматическая загрузка метаданных процедур из database packages/schemas.
 - Обновление метаданных процедур во время работы через уведомления базы.
-- Настраиваемый регистр ключей результата: `camelCase`, `lowerCase`,
-  `snakeCase`.
+- Встроенная case-strategy для native result keys и TypeORM-compatible column
+  names: `camelCase`, `lowerCase`, `snakeCase`.
 - Встроенные и пользовательские сериализаторы значений из базы.
 - Интеграция с NestJS через global dynamic module и decorators для инжекта
   отдельных публичных методов.
@@ -72,7 +144,10 @@
 ## Требования
 
 - Node.js `>=20`
-- npm `>=10`
+- Любой package manager, работающий с npm registry:
+  - npm
+  - Yarn
+  - pnpm
 - TypeScript с включенными decorators, если используются entities
 - Драйвер для целевой базы:
   - PostgreSQL: `pg`
@@ -84,26 +159,92 @@
 
 ## Установка
 
-```bash
-npm install typeorm-procedure-kit
-```
+Используйте удобный package manager:
 
-Для PostgreSQL:
+| Package manager | Команда |
+| --- | --- |
+| npm | `npm install typeorm-procedure-kit` |
+| Yarn | `yarn add typeorm-procedure-kit` |
+| pnpm | `pnpm add typeorm-procedure-kit` |
 
-```bash
-npm install pg
-```
+Установите драйвер для нужной базы.
 
-Для Oracle:
+PostgreSQL:
 
-```bash
-npm install oracledb
-```
+| Package manager | Команда |
+| --- | --- |
+| npm | `npm install pg` |
+| Yarn | `yarn add pg` |
+| pnpm | `pnpm add pg` |
+
+Oracle:
+
+| Package manager | Команда |
+| --- | --- |
+| npm | `npm install oracledb` |
+| Yarn | `yarn add oracledb` |
+| pnpm | `pnpm add oracledb` |
 
 Установите `pg-query-stream` только если используете PostgreSQL streaming:
 
-```bash
-npm install pg-query-stream
+| Package manager | Команда |
+| --- | --- |
+| npm | `npm install pg-query-stream` |
+| Yarn | `yarn add pg-query-stream` |
+| pnpm | `pnpm add pg-query-stream` |
+
+## Быстрый старт
+
+Минимальный PostgreSQL пример инициализирует kit, вызывает одну настроенную
+процедуру и освобождает ресурсы:
+
+```ts
+import { TypeOrmProcedureKit } from 'typeorm-procedure-kit';
+import type { IModuleConfig, ILoggerModule } from 'typeorm-procedure-kit';
+
+const logger: ILoggerModule = {
+  error: console.error,
+  log: console.log,
+  warn: console.warn,
+  debug: console.debug,
+  verbose: console.debug,
+};
+
+const settings: IModuleConfig = {
+  logger,
+  config: {
+    type: 'postgres',
+    parseInt8AsBigInt: true,
+    master: {
+      host: 'localhost',
+      port: 5432,
+      username: 'app',
+      password: 'secret',
+      database: 'app_db',
+    },
+    poolSize: 10,
+    packagesSettings: {
+      packages: ['billing'],
+      procedureObjectList: {
+        findInvoices: 'billing.find_invoices',
+      },
+    },
+  },
+};
+
+const db = new TypeOrmProcedureKit(settings);
+
+await db.initDatabase();
+
+try {
+  const invoices = await db.call<{ invoiceId: number }>(
+    'billing.find_invoices',
+    { customerId: 42 }
+  );
+  console.log(invoices);
+} finally {
+  await db.destroy();
+}
 ```
 
 ## Точки импорта
@@ -124,6 +265,13 @@ Root import экспортирует kit, публичные типы, constants
 query builders и связанные классы экспортируются из `./typeorm`. Для entities,
 которыми управляет kit, импортируйте TypeORM API из
 `typeorm-procedure-kit/typeorm`, а не из отдельного upstream-пакета `typeorm`.
+
+| Import path | Для чего использовать |
+| --- | --- |
+| `typeorm-procedure-kit` | `TypeOrmProcedureKit`, публичные типы, utilities, constants |
+| `typeorm-procedure-kit/nestjs` | NestJS module, service, method injection decorators |
+| `typeorm-procedure-kit/typeorm` | Встроенные TypeORM-compatible decorators, DataSource, repositories, query builders |
+| `typeorm-procedure-kit/typeorm-extend` | `ExtendEntity`, `ExtendColumn` и связанные metadata extension decorators |
 
 ## Конфигурация
 
@@ -204,13 +352,89 @@ const config: IModuleConfig = {
 В примерах для PostgreSQL слово "package" означает настроенное namespace schema,
 которое использует kit. В примерах для Oracle это Oracle package.
 
-Ключи `procedureObjectList` являются метками внутри конфигурации. Вызовы
-разрешаются по значениям, поэтому используйте `db.call('billing.find_invoices')`
-или `db.call('find_invoices')`, если настроен только один package.
+`procedureObjectList` является allowlist для загрузки metadata процедур. Ключи
+служат только метками внутри конфигурации; значения должны быть реальными
+именами процедур в формате `package.procedure` или `schema.procedure`. Runtime
+вызовы разрешаются по загруженным database names, поэтому используйте
+`db.call('billing.find_invoices')` или `db.call('find_invoices')`, если настроен
+только один package. Не используйте ключи `procedureObjectList` как aliases для
+`call()`.
 
-Если задан `packagesSettings.packages`, `initDatabase()` также создает подписку
-на уведомления об изменении packages. Перед использованием этих примеров без
-изменений настройте источник уведомлений в базе.
+Если задан `packagesSettings.packages` и packages array не пустой,
+`initDatabase()` также создает подписку на уведомления об изменении packages.
+Перед использованием этих примеров без изменений настройте источник
+уведомлений в базе.
+
+## Встроенная case-strategy
+
+`typeorm-procedure-kit` включает встроенную case-strategy для двух мест, где
+имена из базы встречаются с application code: native result objects и
+встроенная TypeORM-compatible naming strategy. Настройка задается через
+`config.outKeyTransformCase` внутри database config.
+
+Поддерживаемые значения:
+
+| Значение | Ключ из базы | Ключ на выходе |
+| --- | --- | --- |
+| `camelCase` | `USER_ID`, `user_id`, `user id` | `userId` |
+| `snakeCase` | `USER_ID`, `userId`, `User Id` | `user_id` |
+| `lowerCase` | `USER_ID`, `User_Id` | `user_id` |
+
+Если `outKeyTransformCase` не задан, используется `camelCase`. Неизвестные
+значения во время выполнения также откатываются к `camelCase`.
+
+Пакет создает два strategy objects из одной настройки:
+
+- `NativeStrategy` преобразует имена колонок, которые приходят из metadata
+  `pg` или `oracledb`, перед возвратом native rows из вызовов процедур и raw
+  SQL. SQL aliases тоже преобразуются, потому что drivers отдают aliases как
+  result metadata.
+- `OrmStrategy` устанавливается как DataSource naming strategy при
+  инициализации. Она преобразует имена свойств entity перед передачей во
+  встроенную default naming strategy, поэтому generated column names следуют
+  выбранному формату, если decorator не задает explicit name.
+
+Пример:
+
+```ts
+const config: IModuleConfig = {
+  logger,
+  config: {
+    type: 'postgres',
+    master,
+    poolSize: 10,
+    parseInt8AsBigInt: true,
+    outKeyTransformCase: 'snakeCase',
+  },
+  entity: {
+    isNeedEntitySync: false,
+    entityPath: ['dist/entities/*.js'],
+  },
+  migration: {
+    isNeedMigrationStart: false,
+    migrationPath: ['dist/migrations/*.js'],
+  },
+};
+```
+
+При такой настройке колонка raw result `USER_ID` или `userId` вернется как
+`user_id`. При `camelCase` тот же ключ будет возвращен как `userId`.
+
+Важные детали:
+
+- Стратегия меняет output object keys и generated ORM column names. Она не
+  переписывает package names, procedure names, SQL text, bind placeholders,
+  table names, relation names или notification channel names.
+- `packagesSettings.packages` по-прежнему нужно указывать в lowercase, потому
+  что procedure resolution нормализует configured package/schema names внутри.
+- Raw SQL bind placeholders по-прежнему используют документированный uppercase
+  стиль, например `:USER_ID`.
+- Явно заданные custom column names в decorators учитываются встроенной default
+  naming strategy, поэтому стандартное TypeORM override behavior сохраняется.
+- `lowerCase` только приводит входную строку к нижнему регистру. Используйте
+  `snakeCase`, если нужно разбиение слов, например `User Id` -> `user_id`.
+- Преобразованные имена кэшируются на время жизни kit instance, а cache
+  очищается при `destroy()`.
 
 Oracle CQN можно настроить в двух режимах. Server callback mode открывает
 локальный порт для уведомлений от базы:
@@ -442,7 +666,9 @@ await db.unlistenNotify(channel);
 
 PostgreSQL adapter проверяет имя channel, открывает отдельный `pg.Client`,
 пытается разобрать JSON payload и восстанавливает listener после ошибок
-соединения.
+соединения. Также выполняется периодический health-check соединения, поэтому
+listener может быть восстановлен после тихого сетевого обрыва, когда
+PostgreSQL не прислал явное событие.
 
 ### Oracle Continuous Query Notification
 
@@ -473,13 +699,28 @@ adapter читает измененные строки и передает их 
 каждую operation; возвращенная строка channel содержит сгенерированные имена
 subscriptions, и ее можно без изменений передать в `unlistenNotify()`.
 
+Дефолты Oracle notifications:
+
+- `operations`: `oracledb.CQN_OPCODE_ALL_OPS`
+- `qos`: `oracledb.SUBSCR_QOS_ROWIDS`
+- `timeout`: 12 часов
+- `clientInitiated`: option конкретной subscription, затем общий config, затем
+  `false`
+
+Если `operations` передан как array, в нем должно быть меньше четырех operation
+codes. Для подписки на все операции используйте
+`oracledb.CQN_OPCODE_ALL_OPS`, а не ручной список всех операций. Oracle
+subscriptions также проверяются периодическим health-check и восстанавливаются
+после CQN deregistration, shutdown events, ошибок соединения или тихого обрыва
+соединения.
+
 ## Обновление метаданных packages
 
 Если настроен `packagesSettings.packages`, `initDatabase()` загружает
-метаданные процедур из базы и создает подписку на уведомления об изменении
-packages. У пользователя базы должен быть доступ к источнику уведомлений:
-PostgreSQL по умолчанию слушает `db_object_event`, а Oracle читает
-`SOLUTION_ROOT.DB_OBJECT_LOG`.
+метаданные процедур из базы. Также создается подписка на уведомления об
+изменении packages всякий раз, когда packages array не пустой. У пользователя
+базы должен быть доступ к источнику уведомлений: PostgreSQL по умолчанию слушает
+`db_object_event`, а Oracle читает `SOLUTION_ROOT.DB_OBJECT_LOG`.
 
 Для PostgreSQL можно переопределить notification channel, когда
 `isNeedDynamicallyUpdatePackagesInfo` равен `true`:
@@ -567,19 +808,17 @@ Async setup:
 
 ```ts
 TypeOrmProcedureKitNestModule.forRootAsync({
-  imports: [ConfigModule],
-  inject: [ConfigService],
-  useFactory: async (configService: ConfigService) => ({
+  useFactory: async () => ({
     logger: new Logger('TypeOrmProcedureKit'),
     config: {
       type: 'postgres',
       parseInt8AsBigInt: true,
       master: {
-        host: configService.getOrThrow('DB_HOST'),
-        port: Number(configService.getOrThrow('DB_PORT')),
-        username: configService.getOrThrow('DB_USER'),
-        password: configService.getOrThrow('DB_PASSWORD'),
-        database: configService.getOrThrow('DB_NAME'),
+        host: process.env.DB_HOST ?? 'localhost',
+        port: Number(process.env.DB_PORT ?? 5432),
+        username: process.env.DB_USER ?? 'app',
+        password: process.env.DB_PASSWORD ?? 'secret',
+        database: process.env.DB_NAME ?? 'app_db',
       },
       poolSize: 10,
     },

--- a/package.json
+++ b/package.json
@@ -106,17 +106,14 @@
     "url": "https://github.com/PaulBudanov/typeorm-procedure-kit/issues"
   },
   "dependencies": {
-    "@sqltools/formatter": "^1.2.5",
-    "ansis": "^4.2.0",
     "app-root-path": "^3.1.0",
     "dedent": "^1.7.1",
     "dotenv": "^17.3.1",
     "glob": "^13.0.3",
-    "lodash-es": "^4.17.23",
+    "lodash": "^4.18.1",
     "lru-cache": "^11.2.7",
     "luxon": "^3.7.2",
-    "reflect-metadata": "^0.2.2",
-    "sql-highlight": "^6.1.0"
+    "reflect-metadata": "^0.2.2"
   },
   "peerDependencies": {
     "@nestjs/common": "^10.0.0 || ^11.0.0",
@@ -159,7 +156,7 @@
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.3",
     "@semantic-release/release-notes-generator": "^14.1.0",
-    "@types/lodash-es": "^4.17.12",
+    "@types/lodash": "^4.17.24",
     "@types/luxon": "^3.7.1",
     "@types/node": "^25.2.0",
     "@types/oracledb": "^6.10.1",
@@ -180,8 +177,7 @@
     "vitest": "^4.1.5"
   },
   "engines": {
-    "node": ">=20.0.0",
-    "npm": ">=10.0.0"
+    "node": ">=20.0.0"
   },
   "sideEffects": [
     "./dist/cjs/index.js",

--- a/src/adapters/abstract/database-connection.ts
+++ b/src/adapters/abstract/database-connection.ts
@@ -9,6 +9,8 @@ export abstract class DatabaseConnection<
   U extends TConnectionOptions,
   V extends TConnectionTypes,
 > {
+  private static readonly CONNECTION_HEALTH_CHECK_TIMEOUT_MS = 10000;
+
   protected options: U;
   public constructor(
     protected readonly appDataSource: DataSource,
@@ -20,4 +22,43 @@ export abstract class DatabaseConnection<
   public abstract createSingleConnection(): Promise<V>;
 
   public abstract closeSingleConnection(connection: V): Promise<void>;
+
+  public abstract pingSingleConnection(connection: V): Promise<void>;
+
+  public async isSingleConnectionHealthy(
+    connection: V,
+    timeoutMs = DatabaseConnection.CONNECTION_HEALTH_CHECK_TIMEOUT_MS
+  ): Promise<boolean> {
+    let timeout: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        this.pingSingleConnection(connection),
+        new Promise<never>((_resolve, reject) => {
+          timeout = setTimeout(() => {
+            reject(
+              new Error(
+                `Database connection health check timed out after ${timeoutMs}ms`
+              )
+            );
+          }, timeoutMs);
+          timeout.unref();
+        }),
+      ]);
+      return true;
+    } catch (error: unknown) {
+      this.logger.warn(
+        `Database connection health check failed: ${(error as Error).message}`
+      );
+      return false;
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  }
+
+  public registerConnectionErrorHandler(
+    _connection: V,
+    _callback: () => void | Promise<void>
+  ): void {
+    return;
+  }
 }

--- a/src/adapters/oracle/oracle-connection.ts
+++ b/src/adapters/oracle/oracle-connection.ts
@@ -38,6 +38,14 @@ export class OracleConnection extends DatabaseConnection<
     return oracledb.getConnection(options);
   }
 
+  public override async pingSingleConnection(
+    connection: oracledb.Connection
+  ): Promise<void> {
+    if (!connection.isHealthy())
+      throw new Error('Oracle connection is unhealthy');
+    await connection.ping();
+  }
+
   /**
    * Closes a single Oracle connection object.
    * Logs an error if the connection close process fails.

--- a/src/adapters/oracle/oracle-notify.ts
+++ b/src/adapters/oracle/oracle-notify.ts
@@ -20,6 +20,11 @@ import { OracleConnection } from './oracle-connection.js';
 import { OracleSqlCommand } from './oracle-sql.js';
 
 export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
+  private static readonly CONNECTION_HEALTH_CHECK_INTERVAL_MS = 30000;
+  private readonly healthCheckTimers = new Map<string, NodeJS.Timeout>();
+  private readonly healthChecksInProgress = new Set<string>();
+  private readonly restoringSubscriptions = new Set<string>();
+
   /**
    * Constructor for OracleNotify class.
    * Initializes the OracleNotify object with the provided configuration
@@ -81,6 +86,7 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
 
     const connection = this.notificationPool.get(channelName);
     this.notificationPool.delete(channelName);
+    this.stopConnectionHealthCheck(channelName);
     if (!connection) {
       this.logger.warn(`No active subscription for channel: ${channelName}`);
       return;
@@ -149,7 +155,10 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
               sqlCommand,
               channelName,
               connection
-            )
+            ),
+            sqlCommand,
+            notifyCallback,
+            modifyOptions
           );
         })
       );
@@ -157,16 +166,20 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
     } else {
       const channelName = randomUUID();
       const connection = await this.oracleConnection.createSingleConnection();
+      const modifyOptions = options as TOracleNormilizeOptionsNotify;
       return this.subscribe(
         connection,
         channelName,
         this.generateOptions<T>(
           notifyCallback,
-          options as TOracleNormilizeOptionsNotify,
+          modifyOptions,
           sqlCommand,
           channelName,
           connection
-        )
+        ),
+        sqlCommand,
+        notifyCallback,
+        modifyOptions
       );
     }
   }
@@ -208,14 +221,25 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
    * @returns {Promise<string>} - name of the channel that was subscribed to
    * @throws {Error} - if the subscription fails
    */
-  private async subscribe(
+  private async subscribe<T>(
     connection: oracledb.Connection,
     channelName: string,
-    subscribeOptions: oracledb.SubscribeOptions
+    subscribeOptions: oracledb.SubscribeOptions,
+    sqlCommand: string,
+    notifyCallback: (args: TNotifyCallbackGeneric<T>) => void | Promise<void>,
+    options: TOracleNormilizeOptionsNotify
   ): Promise<string> {
     try {
       await connection.subscribe(channelName, subscribeOptions);
       this.notificationPool.set(channelName, connection);
+      this.startConnectionHealthCheck(channelName, connection, () =>
+        this.restoreSubscriptionCallback<T>(
+          sqlCommand,
+          channelName,
+          notifyCallback,
+          options
+        )
+      );
       this.logger.log(
         `Successfully registered subscription for channel: ${channelName}`
       );
@@ -248,10 +272,11 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
     subscribeUnionOptions: Omit<oracledb.SubscribeOptions, 'callback'>,
     msg: IOracleNotifyMsg
   ): Promise<void> {
-    const options: IOracleOptionsNotify = {
+    const options: TOracleNormilizeOptionsNotify = {
       operations: subscribeUnionOptions.operations,
       qos: subscribeUnionOptions.qos,
       timeout: subscribeUnionOptions.timeout,
+      clientInitiated: subscribeUnionOptions.clientInitiated,
     };
     try {
       if (
@@ -260,7 +285,7 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
           msg.type === oracledb.SUBSCR_EVENT_TYPE_SHUTDOWN) &&
         !msg.registered
       ) {
-        return void this.restoreSubscription<T>(
+        return void this.restoreSubscriptionCallback<T>(
           subscribeUnionOptions.sql,
           channelName,
           notifyCallback,
@@ -342,14 +367,28 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
     sqlCommand: string,
     channelName: string,
     notifyCallback: (args: TNotifyCallbackGeneric<T>) => void | Promise<void>,
-    options: IOracleOptionsNotify,
+    options: TOracleNormilizeOptionsNotify,
     maxRetries = 5,
     retryDelayMs = 1000 * 60 * 5,
     currentRetry = 1
   ): Promise<void> {
     try {
       await this.unlistenNotify(channelName, true);
-      await this.listenNotify(sqlCommand, notifyCallback, options);
+      const connection = await this.oracleConnection.createSingleConnection();
+      await this.subscribe(
+        connection,
+        channelName,
+        this.generateOptions<T>(
+          notifyCallback,
+          options,
+          sqlCommand,
+          channelName,
+          connection
+        ),
+        sqlCommand,
+        notifyCallback,
+        options
+      );
       this.logger.log(
         `Successfully restored subscription for sqlCommand: ${sqlCommand}`
       );
@@ -391,6 +430,74 @@ export class OracleNotify extends DatabaseNotify<oracledb.Connection> {
         retryDelayMs,
         1
       );
+    }
+  }
+
+  private async restoreSubscriptionCallback<T>(
+    sqlCommand: string,
+    channelName: string,
+    notifyCallback: (args: TNotifyCallbackGeneric<T>) => void | Promise<void>,
+    options: TOracleNormilizeOptionsNotify,
+    maxRetries = 5,
+    retryDelayMs = 1000 * 60 * 5,
+    currentRetry = 1
+  ): Promise<void> {
+    if (this.restoringSubscriptions.has(channelName)) return;
+    this.restoringSubscriptions.add(channelName);
+    try {
+      await this.restoreSubscription(
+        sqlCommand,
+        channelName,
+        notifyCallback,
+        options,
+        maxRetries,
+        retryDelayMs,
+        currentRetry
+      );
+    } finally {
+      this.restoringSubscriptions.delete(channelName);
+    }
+  }
+
+  private startConnectionHealthCheck(
+    channelName: string,
+    connection: oracledb.Connection,
+    restore: () => Promise<void>
+  ): void {
+    this.stopConnectionHealthCheck(channelName);
+    const timer = setInterval(() => {
+      void this.checkConnection(channelName, connection, restore);
+    }, OracleNotify.CONNECTION_HEALTH_CHECK_INTERVAL_MS);
+    timer.unref();
+    this.healthCheckTimers.set(channelName, timer);
+  }
+
+  private stopConnectionHealthCheck(channelName: string): void {
+    const timer = this.healthCheckTimers.get(channelName);
+    if (!timer) return;
+    clearInterval(timer);
+    this.healthCheckTimers.delete(channelName);
+  }
+
+  private async checkConnection(
+    channelName: string,
+    connection: oracledb.Connection,
+    restore: () => Promise<void>
+  ): Promise<void> {
+    if (
+      this.notificationPool.get(channelName) !== connection ||
+      this.healthChecksInProgress.has(channelName)
+    )
+      return;
+    this.healthChecksInProgress.add(channelName);
+    try {
+      const isHealthy =
+        await this.oracleConnection.isSingleConnectionHealthy(connection);
+      if (isHealthy) return;
+      if (this.notificationPool.get(channelName) !== connection) return;
+      await restore();
+    } finally {
+      this.healthChecksInProgress.delete(channelName);
     }
   }
 }

--- a/src/adapters/postgres/postgre-connection.ts
+++ b/src/adapters/postgres/postgre-connection.ts
@@ -37,10 +37,17 @@ export class PostgreConnection extends DatabaseConnection<
       password: this.options.password,
       database: this.options.database,
       keepAlive: true,
+      keepAliveInitialDelayMillis: 30000,
     };
     const client = new Client(options);
     await client.connect();
     return client;
+  }
+
+  public override async pingSingleConnection(
+    connection: Client
+  ): Promise<void> {
+    await connection.query('SELECT 1');
   }
 
   /**
@@ -80,33 +87,42 @@ export class PostgreConnection extends DatabaseConnection<
    * @param {(() => void) | Promise<void>} callback - the callback function
    * to be called when the client connection is closed or an error occurs
    */
-  public registerConnectionErrorHandler(
+  public override registerConnectionErrorHandler(
     client: Client,
     callback: () => void | Promise<void>
   ): void {
-    client.on('error', (err) => {
-      this.logger.error(`Postgres client error: ${err.message}`, err.stack);
-      client.removeAllListeners('error');
+    let isHandled = false;
+
+    const handleConnectionLoss = (reason: string, error?: Error): void => {
+      if (isHandled) return;
+      isHandled = true;
+      client.removeListener('error', onError);
+      client.removeListener('end', onEnd);
+      if (error)
+        this.logger.error(
+          `Postgres client ${reason}: ${error.message}`,
+          error.stack
+        );
+      else this.logger.error(`Postgres client ${reason}`);
       try {
         void callback();
-      } catch (error: unknown) {
+      } catch (callbackError: unknown) {
         this.logger.error(
-          `Callback error: ${(error as Error).message}`,
-          (error as Error).stack
+          `Callback error: ${(callbackError as Error).message}`,
+          (callbackError as Error).stack
         );
       }
-    });
-    client.on('end', () => {
-      this.logger.error('Postgres client connection closed');
-      client.removeAllListeners('end');
-      try {
-        void callback();
-      } catch (error: unknown) {
-        this.logger.error(
-          `Callback error: ${(error as Error).message}`,
-          (error as Error).stack
-        );
-      }
-    });
+    };
+
+    const onError = (err: Error): void => {
+      handleConnectionLoss('error', err);
+    };
+
+    const onEnd = (): void => {
+      handleConnectionLoss('connection closed');
+    };
+
+    client.on('error', onError);
+    client.on('end', onEnd);
   }
 }

--- a/src/adapters/postgres/postgre-notify.ts
+++ b/src/adapters/postgres/postgre-notify.ts
@@ -11,6 +11,11 @@ import { DatabaseNotify } from '../abstract/database-notify.js';
 import type { PostgreConnection } from './postgre-connection.js';
 import { PostgreSqlCommand } from './postgre-sql.js';
 export class PostgreNotify extends DatabaseNotify<Client> {
+  private static readonly CONNECTION_HEALTH_CHECK_INTERVAL_MS = 30000;
+  private readonly healthCheckTimers = new Map<string, NodeJS.Timeout>();
+  private readonly healthChecksInProgress = new Set<string>();
+  private readonly restoringChannels = new Set<string>();
+
   public constructor(
     private readonly postgreConnection: PostgreConnection,
     protected readonly logger: ILoggerModule,
@@ -84,6 +89,9 @@ export class PostgreNotify extends DatabaseNotify<Client> {
         return;
       });
       this.notificationPool.set(channelName, client);
+      this.startConnectionHealthCheck(channelName, client, () =>
+        this.restoreClientConnectionCallback<T>(channelName, notifyCallback)
+      );
       this.logger.log(
         `Successfully registered listener for channel: ${channelName}`
       );
@@ -136,6 +144,7 @@ export class PostgreNotify extends DatabaseNotify<Client> {
   public override async unlistenNotify(channel: string): Promise<void> {
     const client = this.notificationPool.get(channel);
     this.notificationPool.delete(channel);
+    this.stopConnectionHealthCheck(channel);
     try {
       if (!client) {
         this.logger.warn(`No listener found for channel: ${channel}`);
@@ -180,6 +189,28 @@ export class PostgreNotify extends DatabaseNotify<Client> {
     retryDelayMs = 30000,
     currentRetry = 1
   ): Promise<void> {
+    if (this.restoringChannels.has(channelName)) return;
+    this.restoringChannels.add(channelName);
+    try {
+      await this.restoreClientConnection(
+        channelName,
+        notifyCallback,
+        maxRetries,
+        retryDelayMs,
+        currentRetry
+      );
+    } finally {
+      this.restoringChannels.delete(channelName);
+    }
+  }
+
+  private async restoreClientConnection<T>(
+    channelName: string,
+    notifyCallback: (args: TNotifyCallbackGeneric<T>) => void | Promise<void>,
+    maxRetries = 5,
+    retryDelayMs = 30000,
+    currentRetry = 1
+  ): Promise<void> {
     try {
       await this.unlistenNotify(channelName);
       if (!channelName.includes('LISTEN ')) {
@@ -206,7 +237,7 @@ export class PostgreNotify extends DatabaseNotify<Client> {
         );
         this.logger.warn('Restarting client connection after 30 min');
         await AsyncUtils.delay(1000 * 60 * 30);
-        await this.restoreClientConnectionCallback(channelName, notifyCallback);
+        await this.restoreClientConnection(channelName, notifyCallback);
         return;
       }
       this.logger.warn(
@@ -215,13 +246,55 @@ export class PostgreNotify extends DatabaseNotify<Client> {
         } seconds... (Attempt ${currentRetry}/${maxRetries})`
       );
       await AsyncUtils.delay(retryDelayMs);
-      await this.restoreClientConnectionCallback(
+      await this.restoreClientConnection(
         channelName,
         notifyCallback,
         maxRetries,
         retryDelayMs,
         currentRetry + 1
       );
+    }
+  }
+
+  private startConnectionHealthCheck(
+    channelName: string,
+    client: Client,
+    restore: () => Promise<void>
+  ): void {
+    this.stopConnectionHealthCheck(channelName);
+    const timer = setInterval(() => {
+      void this.checkClientConnection(channelName, client, restore);
+    }, PostgreNotify.CONNECTION_HEALTH_CHECK_INTERVAL_MS);
+    timer.unref();
+    this.healthCheckTimers.set(channelName, timer);
+  }
+
+  private stopConnectionHealthCheck(channelName: string): void {
+    const timer = this.healthCheckTimers.get(channelName);
+    if (!timer) return;
+    clearInterval(timer);
+    this.healthCheckTimers.delete(channelName);
+  }
+
+  private async checkClientConnection(
+    channelName: string,
+    client: Client,
+    restore: () => Promise<void>
+  ): Promise<void> {
+    if (
+      this.notificationPool.get(channelName) !== client ||
+      this.healthChecksInProgress.has(channelName)
+    )
+      return;
+    this.healthChecksInProgress.add(channelName);
+    try {
+      const isHealthy =
+        await this.postgreConnection.isSingleConnectionHealthy(client);
+      if (isHealthy) return;
+      if (this.notificationPool.get(channelName) !== client) return;
+      await restore();
+    } finally {
+      this.healthChecksInProgress.delete(channelName);
     }
   }
 }

--- a/src/typeorm-extend/decorators/ExtendEntity.ts
+++ b/src/typeorm-extend/decorators/ExtendEntity.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, merge } from 'lodash-es';
+import cloneDeep from 'lodash/cloneDeep.js';
+import merge from 'lodash/merge.js';
 
 import type { EntityOptions } from '../../typeorm/decorator/options/EntityOptions.js';
 import { getMetadataArgsStorage } from '../../typeorm/globals.js';

--- a/src/typeorm/error/DriverPackageNotInstalledError.ts
+++ b/src/typeorm/error/DriverPackageNotInstalledError.ts
@@ -6,7 +6,10 @@ import { TypeORMError } from './TypeORMError.js';
 export class DriverPackageNotInstalledError extends TypeORMError {
   public constructor(driverName: string, packageName: string) {
     super(
-      `${driverName} package has not been found installed. Please run "npm install ${packageName}".`
+      `${driverName} package has not been found installed. ` +
+        `Install it with your package manager, for example: ` +
+        `"npm install ${packageName}", "yarn add ${packageName}", ` +
+        `or "pnpm add ${packageName}".`
     );
   }
 }

--- a/src/typeorm/logger/AdvancedConsoleLogger.ts
+++ b/src/typeorm/logger/AdvancedConsoleLogger.ts
@@ -6,7 +6,7 @@ import type { LogLevel, LogMessage } from './Logger.js';
 
 /**
  * Performs logging of the events in TypeORM.
- * This version of logger uses console to log events and use syntax highlighting.
+ * This version of logger uses console to log events.
  */
 export class AdvancedConsoleLogger extends AbstractLogger {
   /**

--- a/src/typeorm/logger/FormattedConsoleLogger.ts
+++ b/src/typeorm/logger/FormattedConsoleLogger.ts
@@ -6,7 +6,7 @@ import type { LogLevel, LogMessage } from './Logger.js';
 
 /**
  * Performs logging of the events in TypeORM.
- * This version of logger uses console to log events, syntax highlighting and formatting.
+ * This version of logger uses console to log events.
  */
 export class FormattedConsoleLogger extends AbstractLogger {
   /**

--- a/src/typeorm/platform/PlatformTools.ts
+++ b/src/typeorm/platform/PlatformTools.ts
@@ -1,17 +1,26 @@
+/* eslint-disable no-console */
 import { appendFileSync, existsSync } from 'fs';
 import { extname, normalize, resolve } from 'path';
 
-import { format as sqlFormat } from '@sqltools/formatter';
-import type { Config as SqlFormatterConfig } from '@sqltools/formatter/lib/core/types.js';
-import ansi from 'ansis';
 import dotenv from 'dotenv';
-import { highlight } from 'sql-highlight';
 
 import type { TDbConfig } from '../../types/config.types.js';
 
 export { EventEmitter } from 'events';
 export { ReadStream } from 'fs';
 export { Readable, Writable } from 'stream';
+
+const ANSI_RESET = '\u001B[0m';
+const ANSI_GRAY = '\u001B[90m';
+const ANSI_RED = '\u001B[31m';
+const ANSI_YELLOW = '\u001B[33m';
+const ANSI_UNDERLINE = '\u001B[4m';
+const ANSI_BG_RED = '\u001B[41m';
+const ANSI_BLACK = '\u001B[30m';
+
+function colorize(value: unknown, ...codes: Array<string>): string {
+  return `${codes.join('')}${String(value)}${ANSI_RESET}`;
+}
 
 /**
  * Platform-specific tools.
@@ -126,79 +135,55 @@ export class PlatformTools {
   }
 
   /**
-   * Highlights sql string to be printed in the console.
+   * Hook for SQL highlighting. Kept as a no-op to avoid runtime formatter dependencies.
    */
   public static highlightSql(sql: string): string {
-    return highlight(sql, {
-      colors: {
-        keyword: ansi.blueBright.open,
-        function: ansi.magentaBright.open,
-        number: ansi.green.open,
-        string: ansi.white.open,
-        identifier: ansi.white.open,
-        special: ansi.white.open,
-        bracket: ansi.white.open,
-        comment: ansi.gray.open,
-        clear: ansi.reset.open,
-      },
-    });
+    return sql;
   }
 
   /**
-   * Pretty-print sql string to be print in the console.
+   * Hook for SQL formatting. Kept as a no-op to avoid runtime formatter dependencies.
    */
   public static formatSql(
     sql: string,
-    dataSourceType?: TDbConfig['type']
+    _dataSourceType?: TDbConfig['type']
   ): string {
-    const databaseLanguageMap: Record<string, SqlFormatterConfig['language']> =
-      {
-        oracle: 'pl/sql',
-      };
-
-    const databaseLanguage = dataSourceType
-      ? (databaseLanguageMap[dataSourceType] ?? 'sql')
-      : 'sql';
-
-    return sqlFormat(sql, {
-      language: databaseLanguage,
-      indent: '    ',
-    });
+    return sql;
   }
 
   /**
    * Logging functions needed by AdvancedConsoleLogger
    */
   public static logInfo(prefix: string, info: unknown): void {
-    console.log(ansi.gray.underline(prefix), info);
+    console.log(colorize(prefix, ANSI_GRAY, ANSI_UNDERLINE), info);
   }
 
   public static logError(prefix: string, error: unknown): void {
-    console.log(ansi.underline.red(prefix), error);
+    console.log(colorize(prefix, ANSI_RED, ANSI_UNDERLINE), error);
   }
 
   public static logWarn(prefix: string, warning: unknown): void {
-    console.log(ansi.underline.yellow(prefix), warning);
+    console.log(colorize(prefix, ANSI_YELLOW, ANSI_UNDERLINE), warning);
   }
 
   public static log(message: string): void {
-    console.log(ansi.underline(message));
+    console.log(colorize(message, ANSI_UNDERLINE));
   }
 
   public static info(info: unknown): string {
-    return ansi.gray(info);
+    return colorize(info, ANSI_GRAY);
   }
 
   public static error(error: unknown): string {
-    return ansi.red(error);
+    return colorize(error, ANSI_RED);
   }
 
   public static warn(message: string): string {
-    return ansi.yellow(message);
+    return colorize(message, ANSI_YELLOW);
   }
 
   public static logCmdErr(prefix: string, err?: unknown): void {
-    console.log(ansi.black.bgRed(prefix));
+    console.log(colorize(prefix, ANSI_BLACK, ANSI_BG_RED));
     if (err) console.error(err);
   }
 

--- a/src/utils/string-utilities.ts
+++ b/src/utils/string-utilities.ts
@@ -1,4 +1,5 @@
-import { camelCase, snakeCase } from 'lodash-es';
+import camelCase from 'lodash/camelCase.js';
+import snakeCase from 'lodash/snakeCase.js';
 export abstract class StringUtilities {
   public static toCamelCase(input: string | undefined): string {
     return camelCase(input);

--- a/src/utils/typeorm-helpers.ts
+++ b/src/utils/typeorm-helpers.ts
@@ -1,4 +1,5 @@
-import { cloneDeep, merge } from 'lodash-es';
+import cloneDeep from 'lodash/cloneDeep.js';
+import merge from 'lodash/merge.js';
 
 import type { ColumnMetadataArgs } from '../typeorm/metadata-args/ColumnMetadataArgs.js';
 import type { GeneratedMetadataArgs } from '../typeorm/metadata-args/GeneratedMetadataArgs.js';


### PR DESCRIPTION
Add shared database connection health-check abstractions and use them in PostgreSQL and Oracle adapters to detect broken connections even when the database does not emit an explicit disconnect notification.

Improve notification recovery by adding guarded restore flows, health-check timers, and connection-specific error handlers for PostgreSQL LISTEN/NOTIFY and Oracle CQN subscriptions.

Replace ESM-only/runtime-problematic dependencies with CJS-compatible best practice imports:
- replace lodash-es with lodash subpath imports
- remove ansis, @sqltools/formatter, and sql-highlight
- keep console logger coloring local and dependency-free

Update package installation guidance to include npm, yarn, and pnpm commands.

Document the built-in case strategy in both English and Russian README files, including supported output key transforms, defaults, affected strategies, and important naming limitations.